### PR TITLE
add option for filtering out deprecated ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,12 +10,22 @@ function hasValidSpdxLicenseId(license) {
   return !license.licenseId.endsWith('+');
 }
 
+function isNotDeprecated(license) {
+  return !license.isDeprecatedLicenseId;
+}
+
 function getLicenseId(license) {
   return license.licenseId;
 }
 
-function extractSpdxLicenseIds(response) {
-  return response.body.licenses.filter(hasValidSpdxLicenseId).map(getLicenseId);
+function extractSpdxLicenseIds(omitDeprecated) {
+  return function(response) {
+    var results = response.body.licenses.filter(hasValidSpdxLicenseId);
+    if (omitDeprecated) {
+      results = results.filter(isNotDeprecated);
+    }
+    return results.map(getLicenseId);
+  };
 }
 
 module.exports = function getSpdxLicenseIds(options) {
@@ -31,5 +41,5 @@ module.exports = function getSpdxLicenseIds(options) {
   }, options, {
     json: true
   }))
-  .then(extractSpdxLicenseIds);
+  .then(extractSpdxLicenseIds(options && options.omitDeprecated));
 };

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const getSpdxLicenseIds = require('.');
 const test = require('tape');
 
 test('getSpdxLicenseIds()', t => {
-  t.plan(5);
+  t.plan(6);
 
   t.strictEqual(getSpdxLicenseIds.name, 'getSpdxLicenseIds', 'should have a function name.');
 
@@ -23,6 +23,14 @@ test('getSpdxLicenseIds()', t => {
       ids.includes('GPL-1.0+'),
       false,
       'should be fulfilled with an array that doesn\'t include any SPDX expressions.'
+    );
+  }).catch(t.fail);
+
+  getSpdxLicenseIds({omitDeprecated: true}).then(ids => {
+    t.strictEqual(
+      ids.includes('WXwindows'),
+      false,
+      'should be fulfilled with an array that doesn\'t include any deprecated identifiers.'
     );
   }).catch(t.fail);
 


### PR DESCRIPTION
Adds an additional `options.omitDeprecated` to filter out deprecated license IDs.